### PR TITLE
Lambda Path Changes and Bugfixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,4 +44,4 @@ lambda-lint: ## lint lambda code
 build: ## zips the source code for our lambda functions into the root directory
 	( cd lambda && yarn install )
 	( cd lambda && yarn build )
-	( rm ../lambda.zip 2>/dev/null ; zip -rq ../lambda.zip lambda )
+	( cd lambda && rm ../lambda.zip 2>/dev/null ; zip -rq ../lambda.zip . )

--- a/Makefile
+++ b/Makefile
@@ -44,4 +44,4 @@ lambda-lint: ## lint lambda code
 build: ## zips the source code for our lambda functions into the root directory
 	( cd lambda && yarn install )
 	( cd lambda && yarn build )
-	( rm ../../lambda.zip 2>/dev/null ; zip -rq ../../lambda.zip lambda )
+	( rm ../lambda.zip 2>/dev/null ; zip -rq ../lambda.zip lambda )

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ output "kibana_endpoint" {
 | namespace    | Namespace of this service | `string` |  |
 | cognito_identity_pool_id    | Cognito Identity Pool Id | `string` |  |
 | cognito_user_pool_id    | Cognito User Pool Id | `string` |  |
-| cognito_es_role    | IAM Role used by ElasticSearch to create Cognito Client and credentials | `string` | `CognitoAccessForAmazonES` |
+| cognito_es_role    | IAM Role used by ElasticSearch to create Cognito Client and credentials | `string` | `service/CognitoAccessForAmazonES` |
 | cloudwatch_logs_prefixes    | CloudWatch Logs prefixes to automatically subscribe to ElasticSearch | `string` |  |
 | elasticsearch_instance_count    | Number of Elasticsearch instances | `number` | `1` |
 | elasticsearch_instance_type    | Type of Elasticsearch instances | `string` | `"t2.medium.elasticsearch"` |

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ output "kibana_endpoint" {
 | namespace    | Namespace of this service | `string` |  |
 | cognito_identity_pool_id    | Cognito Identity Pool Id | `string` |  |
 | cognito_user_pool_id    | Cognito User Pool Id | `string` |  |
-| cognito_es_role    | IAM Role used by ElasticSearch to create Cognito Client and credentials | `string` | `service/CognitoAccessForAmazonES` |
+| cognito_es_role    | IAM Role used by ElasticSearch to create Cognito Client and credentials | `string` | `service-role/CognitoAccessForAmazonES` |
 | cloudwatch_logs_prefixes    | CloudWatch Logs prefixes to automatically subscribe to ElasticSearch | `string` |  |
 | elasticsearch_instance_count    | Number of Elasticsearch instances | `number` | `1` |
 | elasticsearch_instance_type    | Type of Elasticsearch instances | `string` | `"t2.medium.elasticsearch"` |

--- a/automate-cloudwatch-logs-subscription.tf
+++ b/automate-cloudwatch-logs-subscription.tf
@@ -33,9 +33,9 @@ resource "aws_lambda_function" "automate-cloudwatch-logs-subscription-lambda" {
 }
 
 resource "aws_lambda_permission" "automate-cloudwatch-logs-subscription-permission" {
-  statement_id = "AllowExecutionFromCloudWatch"
-  action = "lambda:InvokeFunction"
+  statement_id  = "AllowExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.automate-cloudwatch-logs-subscription-lambda.function_name
-  principal = "events.amazonaws.com"
-  source_arn = aws_cloudwatch_event_rule.automate-cloudwatch-logs-subscription-event.arn
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.automate-cloudwatch-logs-subscription-event.arn
 }

--- a/automate-cloudwatch-logs-subscription.tf
+++ b/automate-cloudwatch-logs-subscription.tf
@@ -2,6 +2,9 @@ resource "aws_cloudwatch_event_rule" "automate-cloudwatch-logs-subscription-even
   name                = "${var.namespace}-automate-cwl-sub-event"
   description         = "${var.namespace} - Activates lambda to check for new log groups every ${var.automate_subscription_rate}"
   schedule_expression = "rate(${var.automate_subscription_rate})"
+  depends_on = [
+    aws_lambda_function.automate-cloudwatch-logs-subscription-lambda
+  ]
 }
 
 resource "aws_cloudwatch_event_target" "automate-cloudwatch-logs-subscription-target" {
@@ -27,4 +30,12 @@ resource "aws_lambda_function" "automate-cloudwatch-logs-subscription-lambda" {
       LAMBDA_ARN               = aws_lambda_function.cloudwatch-logs-to-elasticsearch-lambda.arn
     }
   }
+}
+
+resource "aws_lambda_permission" "automate-cloudwatch-logs-subscription-permission" {
+  statement_id = "AllowExecutionFromCloudWatch"
+  action = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.automate-cloudwatch-logs-subscription-lambda.function_name
+  principal = "events.amazonaws.com"
+  source_arn = aws_cloudwatch_event_rule.automate-cloudwatch-logs-subscription-event.arn
 }

--- a/automate-cloudwatch-logs-subscription.tf
+++ b/automate-cloudwatch-logs-subscription.tf
@@ -12,8 +12,8 @@ resource "aws_cloudwatch_event_target" "automate-cloudwatch-logs-subscription-ta
 
 resource "aws_lambda_function" "automate-cloudwatch-logs-subscription-lambda" {
   function_name    = "${var.namespace}-cwl-sub-lambda"
-  filename         = "./lambda.zip"
-  source_code_hash = filebase64sha256("./lambda.zip")
+  filename         = "${path.module}/lambda.zip"
+  source_code_hash = filebase64sha256("${path.module}/lambda.zip")
   handler          = "dist/automate-cloudwatch-logs-subscription.handler"
 
   role        = aws_iam_role.lambda-role.arn

--- a/cloudwatch-logs-to-elasticsearch.tf
+++ b/cloudwatch-logs-to-elasticsearch.tf
@@ -7,8 +7,8 @@ resource "aws_lambda_permission" "cloudwatch-logs-to-elasticsearch-permission" {
 
 resource "aws_lambda_function" "cloudwatch-logs-to-elasticsearch-lambda" {
   function_name    = "${var.namespace}-cwl-to-es-lambda"
-  filename         = "./lambda.zip"
-  source_code_hash = filebase64sha256("./lambda.zip")
+  filename         = "${path.module}/lambda.zip"
+  source_code_hash = filebase64sha256("${path.module}/lambda.zip")
   handler          = "cloudwatch-logs-to-elasticsearch.handler"
 
   role        = aws_iam_role.lambda-role.arn

--- a/elasticsearch.tf
+++ b/elasticsearch.tf
@@ -26,7 +26,7 @@ resource "aws_elasticsearch_domain" "es" {
   cognito_options {
     enabled          = true
     identity_pool_id = "${var.region}:${var.cognito_identity_pool_id}"
-    role_arn         = "arn:aws:iam::${var.account_id}:role/service-role/${var.cognito_es_role}"
+    role_arn         = "arn:aws:iam::${var.account_id}:role/${var.cognito_es_role}"
     user_pool_id     = var.cognito_user_pool_id
   }
 

--- a/lambda-permissions.tf
+++ b/lambda-permissions.tf
@@ -8,8 +8,6 @@ resource "aws_iam_role_policy" "lambda-policy" {
   role        = aws_iam_role.lambda-role.id
   policy = templatefile("${path.module}/policies/lambda_policy.tpl", {
     account_id    = var.account_id,
-    region        = var.region,
-    event_name    = aws_cloudwatch_event_rule.automate-cloudwatch-logs-subscription-event.name,
-    function_name = aws_lambda_function.automate-cloudwatch-logs-subscription-lambda.function_name
+    region        = var.region
   })
 }

--- a/lambda-permissions.tf
+++ b/lambda-permissions.tf
@@ -7,7 +7,7 @@ resource "aws_iam_role_policy" "lambda-policy" {
   name_prefix = "${var.namespace}-lambda-policy"
   role        = aws_iam_role.lambda-role.id
   policy = templatefile("${path.module}/policies/lambda_policy.tpl", {
-    account_id    = var.account_id,
-    region        = var.region
+    account_id = var.account_id,
+    region     = var.region
   })
 }

--- a/lambda-permissions.tf
+++ b/lambda-permissions.tf
@@ -7,8 +7,9 @@ resource "aws_iam_role_policy" "lambda-policy" {
   name_prefix = "${var.namespace}-lambda-policy"
   role        = aws_iam_role.lambda-role.id
   policy = templatefile("${path.module}/policies/lambda_policy.tpl", {
-    account_id = var.account_id,
-    region     = var.region
+    account_id    = var.account_id,
+    region        = var.region,
+    event_name    = aws_cloudwatch_event_rule.automate-cloudwatch-logs-subscription-event.name,
+    function_name = aws_lambda_function.automate-cloudwatch-logs-subscription-lambda.function_name
   })
 }
-

--- a/policies/lambda_policy.tpl
+++ b/policies/lambda_policy.tpl
@@ -22,6 +22,16 @@
       "Resource": [
         "arn:aws:logs:${region}:${account_id}:log-group:*"
       ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": "lambda:InvokeFunction",
+      "Resource": "arn:aws:lambda:${region}:${account_id}:function:${function_name}",
+      "Condition": {
+        "ArnLike": {
+          "AWS:SourceArn": "arn:aws:events:${region}:${account_id}:rule/${event_name}"
+        }
+      }
     }
   ]
 }

--- a/policies/lambda_policy.tpl
+++ b/policies/lambda_policy.tpl
@@ -22,16 +22,6 @@
       "Resource": [
         "arn:aws:logs:${region}:${account_id}:log-group:*"
       ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": "lambda:InvokeFunction",
-      "Resource": "arn:aws:lambda:${region}:${account_id}:function:${function_name}",
-      "Condition": {
-        "ArnLike": {
-          "AWS:SourceArn": "arn:aws:events:${region}:${account_id}:rule/${event_name}"
-        }
-      }
     }
   ]
 }

--- a/vars.tf
+++ b/vars.tf
@@ -24,7 +24,7 @@ variable "cognito_user_pool_id" {
 
 variable "cognito_es_role" {
   type    = string
-  default = "service/CognitoAccessForAmazonES"
+  default = "service-role/CognitoAccessForAmazonES"
 }
 
 variable "elasticsearch_instance_type" {

--- a/vars.tf
+++ b/vars.tf
@@ -23,8 +23,8 @@ variable "cognito_user_pool_id" {
 }
 
 variable "cognito_es_role" {
-  type = string
-  default = "CognitoAccessForAmazonES"
+  type    = string
+  default = "service/CognitoAccessForAmazonES"
 }
 
 variable "elasticsearch_instance_type" {


### PR DESCRIPTION
- Proposal: Lambda Path Changes
    - I think it's best for the Lambda code to stay inside the `.terraform/modules/terraform-aws-elasticsearch-cloudwatch-logs` folder, instead of creating something in the root directory (the user of this module could have their own Lambda code in a `lambda.zip` file, for instance).

- Bugfixes:
    - The default `CognitoAccessForAmazonES` should have path `service-role/CognitoAccessForAmazonES`
    - `automate-cloudwatch-logs-subscription-event` should have permissions to trigger `automate-cloudwatch-logs-subscription-lambda`