### PR TITLE
ESHttp* should be atached to cognito pool Auth role

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ module "elasticsearch_cloudwatch_logs" {
 
   cognito_identity_pool_id = "00000000-0000-0000-0000-000000000000"
   cognito_user_pool_id = "us-east-1_abcdefghi"
-  cognito_es_role = "Cognito_notrenderfarm_Role"
+  cognito_auth_role = "Cognito_notrenderfarm_elkAuth_Role"
 
   cloudwatch_logs_prefixes = [
     "/aws/lambda/notrenderfarm-api", 
@@ -40,6 +40,7 @@ output "kibana_endpoint" {
 | cognito_identity_pool_id    | Cognito Identity Pool Id | `string` |  |
 | cognito_user_pool_id    | Cognito User Pool Id | `string` |  |
 | cognito_es_role    | IAM Role used by ElasticSearch to create Cognito Client and credentials | `string` | `service-role/CognitoAccessForAmazonES` |
+| cognito_auth_role    | IAM Role assumed by authenticated Cognito User | `string` |  |
 | cloudwatch_logs_prefixes    | CloudWatch Logs prefixes to automatically subscribe to ElasticSearch | `string` |  |
 | elasticsearch_instance_count    | Number of Elasticsearch instances | `number` | `1` |
 | elasticsearch_instance_type    | Type of Elasticsearch instances | `string` | `"t2.medium.elasticsearch"` |

--- a/README.md
+++ b/README.md
@@ -66,4 +66,6 @@ It is currently impossible to provision a `cognito_identity_pool` and `cognito_u
 
 Meanwhile, it is necessary to create those resources manually on the AWS Console. There is a great step-by-step guide on the [AWS documentation](https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-cognito-auth.html#es-cognito-auth-identity-providers) detailing how to do just that.
 
+The `cognito_auth_role` argument should be the name of the authenticated role associated with the provided `cognito_user_pool`.
+
 As for the `cognito_es_role` argument, the default `CognitoAccessForAmazonES` should have all the permissions necessary, but if you decide to use your own role, attach the `AmazonESCognitoAccess` policy to the role and it should work as expected.

--- a/elasticsearch.tf
+++ b/elasticsearch.tf
@@ -1,9 +1,9 @@
 resource "aws_elasticsearch_domain" "es" {
   access_policies = templatefile("${path.module}/policies/domain_policy.tpl", {
-    namespace       = var.namespace,
-    account_id      = var.account_id,
-    region          = var.region,
-    cognito_es_role = var.cognito_es_role
+    namespace         = var.namespace,
+    account_id        = var.account_id,
+    region            = var.region,
+    cognito_auth_role = var.cognito_es_role
   })
   advanced_options = {
     "rest.action.multi.allow_explicit_index" = "true"

--- a/policies/domain_policy.tpl
+++ b/policies/domain_policy.tpl
@@ -4,7 +4,7 @@
       "Action":"es:ESHttp*",
       "Effect":"Allow",
       "Principal":{
-        "AWS":"arn:aws:iam::${account_id}:role/${cognito_es_role}"
+        "AWS":"arn:aws:iam::${account_id}:role/${cognito_auth_role}"
       },
       "Resource":"arn:aws:es:${region}:${account_id}:domain/${namespace}"
     }

--- a/vars.tf
+++ b/vars.tf
@@ -27,6 +27,10 @@ variable "cognito_es_role" {
   default = "service-role/CognitoAccessForAmazonES"
 }
 
+variable "cognito_auth_role" {
+  type = string
+}
+
 variable "elasticsearch_instance_type" {
   type    = string
   default = "t2.medium.elasticsearch"


### PR DESCRIPTION
- Adds new `cognito_auth_role` variable which corresponds to the authenticated role of the chosen Cognito Pool
- Grants permission for `es:ESHttp*` action for this role

Closes #5 